### PR TITLE
Add runnable smartphone motion analysis prototype

### DIFF
--- a/SMARTPHONE_VIDEO_ANALYSIS.md
+++ b/SMARTPHONE_VIDEO_ANALYSIS.md
@@ -1,0 +1,120 @@
+# スマートフォン向け動画解析アプリ開発ガイド
+
+## 1. ゴールの定義
+- 対象デバイス: iOS / Android
+- 解析目的: 物体検出、動作認識、姿勢推定など
+- オフライン解析かクラウド連携かを決める
+
+## 2. 要求仕様
+- スマートフォンのカメラ API を利用してライブ映像/録画動画を取得
+- 解析結果をリアルタイムにオーバーレイ表示
+- 解析ログを保存し、後で再分析できるようにする
+- ユーザーインターフェースは直感的で操作が簡単
+
+## 3. 技術スタック候補
+| レイヤ | 技術候補 |
+| --- | --- |
+| フロントエンド | SwiftUI, Jetpack Compose, Flutter, React Native |
+| ネイティブ API | AVFoundation(iOS), CameraX(Android) |
+| 機械学習 | Core ML, TensorFlow Lite, MediaPipe, ONNX Runtime Mobile |
+| バックエンド | Firebase, Supabase, AWS Amplify, FastAPI |
+
+## 4. 機械学習モデルの選択
+1. オープンソースモデルを転移学習 (YOLOv8, MobileNet, EfficientDet 等)
+2. 自前データセットのアノテーション (LabelImg, CVAT, Roboflow)
+3. TensorFlow Lite / Core ML 形式に最適化
+4. 量子化や pruning で推論速度を改善
+
+## 5. アプリアーキテクチャ
+```
++-------------------------+
+|        UI 層            |
+| (SwiftUI / Compose)     |
++-----------+-------------+
+            |
++-----------v-------------+
+|     カメラ制御層        |
+| (AVFoundation / CameraX)|
++-----------+-------------+
+            |
++-----------v-------------+
+|   ML 推論エンジン       |
+| (TF Lite / Core ML)     |
++-----------+-------------+
+            |
++-----------v-------------+
+|   データ管理・通信層    |
+| (ローカルDB / API)      |
++-------------------------+
+```
+
+## 6. プロトタイピング手順
+1. PoC として TensorFlow Lite + Android CameraX で動くサンプルを作成
+2. iOS に移植し、Core ML で同等の推論を実装
+3. UI/UX を改善し、解析結果の可視化 (バウンディングボックス、グラフなど)
+4. 性能計測 (FPS, CPU/GPU 使用率) と最適化
+
+## 7. テスト戦略
+- 単体テスト: ML 推論結果の整合性
+- UI テスト: 主要操作フロー (撮影、解析、保存)
+- E2E テスト: 実機での長時間連続解析
+- ベンチマーク: モデル推論時間、消費電力、発熱
+
+## 8. セキュリティ・プライバシー
+- カメラ利用許可を明確に説明
+- 解析データの暗号化保存
+- クラウド転送時は HTTPS + 認証
+- 個人情報が映り込む場合のマスキング
+
+## 9. 運用
+- クラッシュログ収集 (Firebase Crashlytics 等)
+- モデル更新の配信 (App 更新 or A/B テスト)
+- ユーザーからのフィードバック収集と改善
+
+## 10. 参考リソース
+- [TensorFlow Lite Examples](https://www.tensorflow.org/lite/examples)
+- [Apple Developer - Vision Framework](https://developer.apple.com/documentation/vision)
+- [Android CameraX](https://developer.android.com/training/camerax)
+- [MediaPipe Solutions](https://developers.google.com/mediapipe)
+
+このガイドを起点に、具体的なユースケースに合わせて要件を肉付けしてください。
+
+## 11. Python ベースの PoC 実装例
+スマートフォンアプリを実装する前に、OpenCV を使った PoC (概念実証) を PC で動かしておくと、
+アルゴリズムの検証やパラメータ調整が容易です。本リポジトリには Python 製のモーション検出
+ツール `analyze_video.py` とユーティリティ `mobile_video_analysis` が含まれています。
+
+### セットアップ
+1. Python 3.10 以上をインストール
+2. 依存関係をインストール
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. スマートフォンで IP カメラ化アプリ (IP Webcam / DroidCam / OBS Camera 等) を起動し、
+   Wi-Fi 経由でアクセスできる URL を控える
+
+### 実行方法
+```bash
+python analyze_video.py \
+  --source "http://<smartphone-ip>:<port>/video" \
+  --record-out output.mp4 \
+  --save-metrics logs/session.json \
+  --overlay-mask
+```
+- `--source` は数値を指定すると PC の USB カメラを利用、URL を渡すと IP カメラ配信を解析
+- `--record-out` で解析済み映像を保存 (mp4v)
+- `--save-metrics` で各フレームの検出情報を JSON で保存
+- `--overlay-mask` で検出領域のヒートマップを重ねて可視化
+- `--max-frames` を指定すると検証用に処理フレーム数を制限
+
+### テスト
+```bash
+pytest
+```
+OpenCV がインストールされていない環境ではテストはスキップされます。CI や開発マシンでは
+`opencv-python` の導入後にテストを実行し、モーション検出のロジックを担保してください。
+
+### PoC の活用
+- 取得した `logs/session.json` から動きが多い区間を抽出し、スマホアプリの UI 設計に反映
+- `MotionAnalyzer` のパラメータ (学習率、しきい値、最小面積) を調整し、ノイズ耐性を評価
+- スマホ実装では ML Kit / MediaPipe などに置き換える際の比較ベースラインとして活用

--- a/analyze_video.py
+++ b/analyze_video.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Command line utility for analysing smartphone camera video streams."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import cv2  # type: ignore
+
+from mobile_video_analysis import MotionAnalyzer
+
+
+def _parse_source(value: str) -> int | str:
+    if value.isdigit():
+        return int(value)
+    return value
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Analyse a video feed (e.g. from a smartphone IP camera app) and detect motion in real time."
+        )
+    )
+    parser.add_argument(
+        "--source",
+        default="0",
+        help="Camera index or URL (for IP camera streams from a smartphone app).",
+    )
+    parser.add_argument(
+        "--width", type=int, default=None, help="Optional override for capture width."
+    )
+    parser.add_argument(
+        "--height", type=int, default=None, help="Optional override for capture height."
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.05,
+        help="Learning rate for the running background model (0 < alpha <= 1).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=25,
+        help="Pixel intensity threshold for motion detection.",
+    )
+    parser.add_argument(
+        "--min-area",
+        type=int,
+        default=500,
+        help="Minimum contour area in pixels required to report motion.",
+    )
+    parser.add_argument(
+        "--dilate-iterations",
+        type=int,
+        default=2,
+        help="Number of dilation iterations applied to the motion mask.",
+    )
+    parser.add_argument(
+        "--blur-kernel",
+        type=int,
+        default=21,
+        help="Odd-sized Gaussian blur kernel for noise reduction.",
+    )
+    parser.add_argument(
+        "--record-out",
+        type=Path,
+        default=None,
+        help="Optional path to save the annotated video (mp4v codec).",
+    )
+    parser.add_argument(
+        "--save-metrics",
+        type=Path,
+        default=None,
+        help="Optional path to a JSON file with per-frame detection metadata.",
+    )
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=None,
+        help="Stop after processing this many frames (useful for testing).",
+    )
+    parser.add_argument(
+        "--display",
+        action="store_true",
+        help="Display the annotated video stream in a window (press q to exit).",
+    )
+    parser.add_argument(
+        "--overlay-mask",
+        action="store_true",
+        help="Overlay the binary motion mask on top of the annotated frame.",
+    )
+    return parser
+
+
+def _initialise_writer(
+    path: Path, frame_shape: tuple[int, int, int], fps: float
+) -> cv2.VideoWriter:
+    height, width = frame_shape[:2]
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    return cv2.VideoWriter(str(path), fourcc, fps, (width, height))
+
+
+def run(args: argparse.Namespace) -> Dict[str, Any]:
+    source = _parse_source(args.source)
+
+    analyzer = MotionAnalyzer(
+        alpha=args.alpha,
+        threshold=args.threshold,
+        min_area=args.min_area,
+        dilate_iterations=args.dilate_iterations,
+        blur_kernel=args.blur_kernel,
+    )
+
+    capture = cv2.VideoCapture(source)
+    if not capture.isOpened():
+        raise RuntimeError(f"Unable to open video source: {source}")
+
+    if args.width:
+        capture.set(cv2.CAP_PROP_FRAME_WIDTH, float(args.width))
+    if args.height:
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, float(args.height))
+
+    metrics: Dict[str, Any] = {
+        "frames": 0,
+        "motion_frames": 0,
+        "detections": [],
+        "source": source,
+    }
+
+    writer: cv2.VideoWriter | None = None
+    fps = capture.get(cv2.CAP_PROP_FPS)
+    if fps <= 0:
+        fps = 30.0
+
+    start_time = time.time()
+
+    try:
+        while True:
+            ret, frame = capture.read()
+            if not ret:
+                break
+
+            metrics["frames"] += 1
+            result = analyzer.process(frame)
+            if result.has_motion():
+                metrics["motion_frames"] += 1
+
+            annotated = analyzer.annotate_frame(frame, result.detections)
+            if args.overlay_mask:
+                annotated = analyzer.overlay_mask(annotated, result.mask)
+
+            if args.record_out and writer is None:
+                writer = _initialise_writer(args.record_out, annotated.shape, fps)
+            if writer is not None:
+                writer.write(annotated)
+
+            if args.display:
+                cv2.imshow("Mobile Motion Analysis", annotated)
+                if cv2.waitKey(1) & 0xFF == ord("q"):
+                    break
+
+            metrics["detections"].append(
+                {
+                    "frame_index": metrics["frames"] - 1,
+                    "detections": MotionAnalyzer.detections_to_dict(result.detections),
+                }
+            )
+
+            if args.max_frames and metrics["frames"] >= args.max_frames:
+                break
+    finally:
+        capture.release()
+        if writer is not None:
+            writer.release()
+        if args.display:
+            cv2.destroyAllWindows()
+
+    elapsed = time.time() - start_time
+    metrics["elapsed_seconds"] = elapsed
+    metrics["average_fps"] = (
+        metrics["frames"] / elapsed if elapsed > 0 else None
+    )
+    return metrics
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        metrics = run(args)
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        parser.error(str(exc))
+        return 2
+
+    if args.save_metrics:
+        args.save_metrics.parent.mkdir(parents=True, exist_ok=True)
+        args.save_metrics.write_text(
+            json.dumps(metrics, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    summary = (
+        f"Processed {metrics['frames']} frames; "
+        f"motion detected in {metrics['motion_frames']} frames; "
+        f"average FPS: {metrics['average_fps']:.2f}"
+        if metrics["average_fps"] is not None
+        else f"Processed {metrics['frames']} frames; motion detected in {metrics['motion_frames']} frames."
+    )
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mobile_video_analysis/__init__.py
+++ b/mobile_video_analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Mobile video analysis helpers."""
+
+from .analyzer import MotionAnalyzer, MotionDetection, MotionDetectionResult
+
+__all__ = ["MotionAnalyzer", "MotionDetection", "MotionDetectionResult"]

--- a/mobile_video_analysis/analyzer.py
+++ b/mobile_video_analysis/analyzer.py
@@ -1,0 +1,191 @@
+"""Utilities for real-time motion analysis using OpenCV."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+try:  # pragma: no cover - import guard
+    import numpy as np  # type: ignore
+except ImportError as exc:  # pragma: no cover - handled by raising later
+    np = None  # type: ignore
+    _numpy_import_error = exc
+else:
+    _numpy_import_error = None
+
+try:  # pragma: no cover - import guard
+    import cv2  # type: ignore
+except ImportError as exc:  # pragma: no cover - handled by raising later
+    cv2 = None  # type: ignore
+    _cv2_import_error = exc
+else:
+    _cv2_import_error = None
+
+
+@dataclass(frozen=True)
+class MotionDetection:
+    """Represents a single motion detection bounding box."""
+
+    bbox: Tuple[int, int, int, int]
+    area: int
+    centroid: Tuple[float, float]
+
+
+@dataclass
+class MotionDetectionResult:
+    """Container for the binary mask and detections from a frame."""
+
+    detections: List[MotionDetection]
+    mask: "np.ndarray"
+
+    def has_motion(self) -> bool:
+        """Return ``True`` when at least one detection is present."""
+
+        return bool(self.detections)
+
+
+class MotionAnalyzer:
+    """Detect motion in frames using a running background model."""
+
+    def __init__(
+        self,
+        *,
+        alpha: float = 0.05,
+        threshold: int = 25,
+        min_area: int = 500,
+        dilate_iterations: int = 2,
+        blur_kernel: int = 21,
+    ) -> None:
+        if np is None:  # pragma: no cover - triggered when NumPy is missing
+            raise ImportError(
+                "MotionAnalyzer requires the numpy package."
+            ) from _numpy_import_error
+        if cv2 is None:  # pragma: no cover - triggered when OpenCV is missing
+            raise ImportError(
+                "MotionAnalyzer requires the opencv-python package."
+            ) from _cv2_import_error
+
+        if not 0 < alpha <= 1:
+            raise ValueError("alpha must be within (0, 1]")
+        if threshold <= 0:
+            raise ValueError("threshold must be positive")
+        if min_area <= 0:
+            raise ValueError("min_area must be positive")
+        if dilate_iterations < 0:
+            raise ValueError("dilate_iterations cannot be negative")
+        if blur_kernel % 2 == 0:
+            raise ValueError("blur_kernel must be an odd number to satisfy OpenCV requirements")
+
+        self.alpha = alpha
+        self.threshold = threshold
+        self.min_area = min_area
+        self.dilate_iterations = dilate_iterations
+        self.blur_kernel = blur_kernel
+
+        self._avg_frame: "np.ndarray | None" = None
+
+    def reset(self) -> None:
+        """Reset the running background model."""
+
+        self._avg_frame = None
+
+    def process(self, frame: "np.ndarray") -> MotionDetectionResult:
+        """Analyse a frame and return detected motion bounding boxes."""
+
+        if frame.size == 0:
+            raise ValueError("frame must contain data")
+
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+
+        frame_float = frame.astype(np.float32)
+        if self._avg_frame is None:
+            self._avg_frame = frame_float
+            mask = np.zeros(frame.shape[:2], dtype=np.uint8)
+            return MotionDetectionResult([], mask)
+
+        cv2.accumulateWeighted(frame_float, self._avg_frame, self.alpha)
+        avg_frame_uint8 = cv2.convertScaleAbs(self._avg_frame)
+        delta = cv2.absdiff(frame, avg_frame_uint8)
+
+        if frame.ndim == 3 and frame.shape[2] == 3:
+            gray = cv2.cvtColor(delta, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = delta if delta.ndim == 2 else delta.squeeze()
+
+        if self.blur_kernel > 0:
+            gray = cv2.GaussianBlur(gray, (self.blur_kernel, self.blur_kernel), 0)
+
+        _, thresh = cv2.threshold(gray, self.threshold, 255, cv2.THRESH_BINARY)
+        if self.dilate_iterations:
+            thresh = cv2.dilate(thresh, None, iterations=self.dilate_iterations)
+
+        contours, _ = cv2.findContours(
+            thresh.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+
+        detections: List[MotionDetection] = []
+        for contour in contours:
+            area = int(cv2.contourArea(contour))
+            if area < self.min_area:
+                continue
+
+            x, y, w, h = cv2.boundingRect(contour)
+            moments = cv2.moments(contour)
+            if moments["m00"]:
+                cx = float(moments["m10"] / moments["m00"])
+                cy = float(moments["m01"] / moments["m00"])
+            else:
+                cx = float(x + w / 2)
+                cy = float(y + h / 2)
+
+            detections.append(MotionDetection((x, y, w, h), area, (cx, cy)))
+
+        return MotionDetectionResult(detections, thresh)
+
+    def annotate_frame(
+        self, frame: "np.ndarray", detections: Sequence[MotionDetection]
+    ) -> "np.ndarray":
+        """Return a copy of ``frame`` with bounding boxes drawn."""
+
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+
+        annotated = frame.copy()
+        for detection in detections:
+            x, y, w, h = detection.bbox
+            cv2.rectangle(annotated, (x, y), (x + w, y + h), (0, 255, 0), 2)
+            label = f"area={detection.area}"
+            cv2.putText(
+                annotated,
+                label,
+                (x, max(y - 5, 0)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (0, 255, 0),
+                1,
+                cv2.LINE_AA,
+            )
+        return annotated
+
+    @staticmethod
+    def overlay_mask(frame: "np.ndarray", mask: "np.ndarray", *, alpha: float = 0.35) -> "np.ndarray":
+        """Overlay the binary mask on top of the frame for visualisation."""
+
+        if frame.ndim != 3:
+            raise ValueError("frame must be a colour image for mask overlay")
+        if mask.ndim != 2:
+            raise ValueError("mask must be a single channel image")
+
+        mask_coloured = np.zeros_like(frame)
+        mask_coloured[:, :, 2] = mask  # red channel
+        blended = cv2.addWeighted(frame, 1 - alpha, mask_coloured, alpha, 0)
+        return blended
+
+    @staticmethod
+    def detections_to_dict(detections: Iterable[MotionDetection]) -> List[dict]:
+        """Serialise detections into JSON-friendly dictionaries."""
+
+        return [
+            {"bbox": det.bbox, "area": det.area, "centroid": det.centroid}
+            for det in detections
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python>=4.8.0.76
+numpy>=1.24.0

--- a/tests/test_motion_analyzer.py
+++ b/tests/test_motion_analyzer.py
@@ -1,0 +1,58 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+cv2 = pytest.importorskip("cv2")
+
+from mobile_video_analysis import MotionAnalyzer
+
+
+def create_frame():
+    return np.zeros((120, 160, 3), dtype=np.uint8)
+
+
+def test_motion_detection_identifies_simple_object():
+    analyzer = MotionAnalyzer(alpha=0.4, threshold=10, min_area=50, blur_kernel=5, dilate_iterations=1)
+
+    background = create_frame()
+    analyzer.process(background)
+
+    moving = background.copy()
+    cv2.rectangle(moving, (50, 40), (80, 70), (255, 255, 255), -1)
+
+    result = analyzer.process(moving)
+    assert result.has_motion()
+    assert len(result.detections) == 1
+
+    detection = result.detections[0]
+    x, y, w, h = detection.bbox
+    assert w * h >= 900
+    assert detection.area >= 800
+    assert 60 <= detection.centroid[0] <= 70
+    assert 50 <= detection.centroid[1] <= 60
+
+
+def test_overlay_mask_preserves_shape():
+    analyzer = MotionAnalyzer(alpha=0.3, threshold=5, min_area=20, blur_kernel=5, dilate_iterations=1)
+
+    frame = create_frame()
+    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
+    mask[10:20, 10:20] = 255
+
+    overlaid = analyzer.overlay_mask(frame, mask)
+    assert overlaid.shape == frame.shape
+    assert overlaid.dtype == frame.dtype
+
+
+def test_detections_serialisation():
+    analyzer = MotionAnalyzer(alpha=0.3, threshold=5, min_area=20, blur_kernel=5, dilate_iterations=1)
+
+    base = create_frame()
+    analyzer.process(base)
+
+    frame = base.copy()
+    cv2.circle(frame, (30, 30), 10, (255, 255, 255), -1)
+    result = analyzer.process(frame)
+    serialised = analyzer.detections_to_dict(result.detections)
+
+    assert isinstance(serialised, list)
+    assert serialised and "bbox" in serialised[0]


### PR DESCRIPTION
## Summary
- add an OpenCV-based motion analysis CLI and supporting module for prototyping smartphone video analytics on desktop
- capture dependency list and pytest-based regression tests for the motion detector utilities
- extend the Japanese project guide with setup, execution, and testing instructions for the new proof-of-concept tooling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb2e3174b4832ea432f3b0e227b213