### PR TITLE
Add SwiftUI MVP training diary app for corporate athletes

### DIFF
--- a/TrainingDiaryApp/Models/AlertRuleEngine.swift
+++ b/TrainingDiaryApp/Models/AlertRuleEngine.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct AlertRuleEngine {
+    func evaluate(record: DailyRecord?) -> (AlertLevel, [String]) {
+        guard let record else {
+            return (.caution, ["今日の入力が未完了"])
+        }
+
+        var reasons: [String] = []
+
+        if let morning = record.morningCheckIn {
+            if morning.sleepHours < 5 {
+                reasons.append("睡眠5時間未満")
+            }
+            if morning.fatigueLevel >= 4 {
+                reasons.append("疲労感が高い")
+            }
+            if morning.hadOvertime {
+                reasons.append("残業あり")
+            }
+        }
+
+        if let training = record.trainingLog {
+            if training.hasPain {
+                reasons.append("痛みあり")
+            }
+            if training.rpe >= 8 {
+                reasons.append("RPEが高い")
+            }
+        }
+
+        switch reasons.count {
+        case 0:
+            return (.normal, ["問題なし"])
+        case 1:
+            return (.caution, reasons)
+        default:
+            return (.warning, reasons)
+        }
+    }
+}

--- a/TrainingDiaryApp/Models/DiaryRepository.swift
+++ b/TrainingDiaryApp/Models/DiaryRepository.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol DiaryRepository {
+    func fetchAthletes() -> [Athlete]
+    func fetchDailyRecords() -> [DailyRecord]
+    func fetchComments() -> [CoachComment]
+}
+
+struct InMemoryDiaryRepository: DiaryRepository {
+    func fetchAthletes() -> [Athlete] {
+        SampleData.athletes
+    }
+
+    func fetchDailyRecords() -> [DailyRecord] {
+        SampleData.dailyRecords
+    }
+
+    func fetchComments() -> [CoachComment] {
+        SampleData.comments
+    }
+}

--- a/TrainingDiaryApp/Models/TrainingDiaryModels.swift
+++ b/TrainingDiaryApp/Models/TrainingDiaryModels.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct Athlete: Identifiable, Codable, Hashable {
+    let id: UUID
+    var name: String
+    var company: String
+    var event: String
+}
+
+struct MorningCheckIn: Codable, Hashable {
+    var date: Date
+    var sleepHours: Double
+    var sleepQuality: Int
+    var fatigueLevel: Int
+    var muscleSoreness: Int
+    var moodLevel: Int
+    var physicalConditionMemo: String
+    var workHours: Double
+    var hadOvertime: Bool
+    var workStressLevel: Int
+}
+
+struct TrainingLog: Codable, Hashable {
+    var date: Date
+    var didTrain: Bool
+    var menuName: String
+    var distanceKm: Double?
+    var durationMinutes: Int?
+    var rpe: Int
+    var hasPain: Bool
+    var painArea: String
+    var trainingMemo: String
+}
+
+struct CoachComment: Identifiable, Codable, Hashable {
+    let id: UUID
+    var athleteID: UUID
+    var date: Date
+    var authorName: String
+    var message: String
+}
+
+struct DailyRecord: Identifiable, Codable, Hashable {
+    let id: UUID
+    var athleteID: UUID
+    var date: Date
+    var morningCheckIn: MorningCheckIn?
+    var trainingLog: TrainingLog?
+}
+
+enum AlertLevel: String, Codable {
+    case normal
+    case caution
+    case warning
+}
+
+struct AthleteDailyStatus: Identifiable {
+    let id = UUID()
+    let athlete: Athlete
+    let record: DailyRecord?
+    let alertLevel: AlertLevel
+    let alertReasons: [String]
+}

--- a/TrainingDiaryApp/README_MVP.md
+++ b/TrainingDiaryApp/README_MVP.md
@@ -1,0 +1,74 @@
+# 練習日誌アプリ MVP 設計
+
+## 1. アプリ全体の設計方針
+- **目的**: 社会人アスリートの状態把握を、毎日短時間の入力で実現する。
+- **MVP重視**: 朝チェックイン・練習後入力・指導者一覧・コメントの最小導線を優先。
+- **構成**: SwiftUI + MVVM。
+  - Model: データ構造・ルール判定
+  - ViewModel: 画面からの更新処理、状態集約
+  - View: 入力UI/一覧UI
+  - SampleData: ダミーデータ
+- **将来拡張**: `DiaryRepository` プロトコルでデータ層を抽象化し、Firebase/CloudKitへ置換しやすくする。
+
+## 2. 画面一覧
+1. 選手ホーム画面
+2. 朝チェックイン画面
+3. 練習後入力画面
+4. 指導者ダッシュボード画面
+5. 選手詳細画面
+6. コメント確認画面
+
+## 3. データモデル設計
+- `Athlete`: 選手マスタ
+- `MorningCheckIn`: 朝入力
+- `TrainingLog`: 練習後入力
+- `DailyRecord`: 1日単位の集約
+- `CoachComment`: 指導者コメント
+- `AlertRuleEngine`: ルールベース判定
+  - 睡眠5時間未満
+  - 疲労感4以上
+  - 痛みあり
+  - 残業あり
+  - RPE8以上
+
+## 4. ディレクトリ構成
+```
+TrainingDiaryApp/
+  TrainingDiaryApp.swift
+  Models/
+    TrainingDiaryModels.swift
+    AlertRuleEngine.swift
+    DiaryRepository.swift
+  ViewModels/
+    DiaryStore.swift
+  Views/
+    RootTabView.swift
+    Athlete/
+      AthleteHomeView.swift
+      MorningCheckInView.swift
+      TrainingLogView.swift
+      CommentListView.swift
+    Coach/
+      CoachDashboardView.swift
+      AthleteDetailView.swift
+    Common/
+      AlertBadgeView.swift
+      RatingInputRow.swift
+  SampleData/
+    SampleData.swift
+```
+
+## 5. SwiftUIコード一式
+- 上記ディレクトリ配下の `.swift` ファイルに実装。
+
+## 6. ダミーデータ
+- 日本語名の3選手を定義。
+- 状態良好/注意/警告が混在する当日データを投入。
+- 指導者コメントの初期データを投入。
+
+## 7. 次に改善すべき点
+1. 永続化（UserDefaults/SQLite/Firebase）
+2. 通知（未入力リマインド）
+3. 複数日トレンド可視化（疲労・睡眠・RPE）
+4. チーム/ロール別認証
+5. 入力最適化（テンプレート・前日コピー）

--- a/TrainingDiaryApp/SampleData/SampleData.swift
+++ b/TrainingDiaryApp/SampleData/SampleData.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+enum SampleData {
+    static let athletes: [Athlete] = [
+        Athlete(id: UUID(uuidString: "D2A0D6A8-7EF4-4F81-BE95-7B96D2A7A001")!, name: "山田 太郎", company: "淡路建設", event: "短距離"),
+        Athlete(id: UUID(uuidString: "D2A0D6A8-7EF4-4F81-BE95-7B96D2A7A002")!, name: "佐藤 花子", company: "淡路食品", event: "中距離"),
+        Athlete(id: UUID(uuidString: "D2A0D6A8-7EF4-4F81-BE95-7B96D2A7A003")!, name: "鈴木 一樹", company: "淡路運輸", event: "長距離")
+    ]
+
+    static let dailyRecords: [DailyRecord] = {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        return [
+            DailyRecord(
+                id: UUID(),
+                athleteID: athletes[0].id,
+                date: today,
+                morningCheckIn: MorningCheckIn(
+                    date: today,
+                    sleepHours: 4.8,
+                    sleepQuality: 2,
+                    fatigueLevel: 4,
+                    muscleSoreness: 3,
+                    moodLevel: 3,
+                    physicalConditionMemo: "やや頭重感あり",
+                    workHours: 9.5,
+                    hadOvertime: true,
+                    workStressLevel: 4
+                ),
+                trainingLog: TrainingLog(
+                    date: today,
+                    didTrain: true,
+                    menuName: "インターバル走",
+                    distanceKm: 8.0,
+                    durationMinutes: 55,
+                    rpe: 8,
+                    hasPain: true,
+                    painArea: "右ハムストリング",
+                    trainingMemo: "後半で張りを感じたため本数を減らした"
+                )
+            ),
+            DailyRecord(
+                id: UUID(),
+                athleteID: athletes[1].id,
+                date: today,
+                morningCheckIn: MorningCheckIn(
+                    date: today,
+                    sleepHours: 6.5,
+                    sleepQuality: 4,
+                    fatigueLevel: 2,
+                    muscleSoreness: 2,
+                    moodLevel: 4,
+                    physicalConditionMemo: "体調良好",
+                    workHours: 8.0,
+                    hadOvertime: false,
+                    workStressLevel: 2
+                ),
+                trainingLog: TrainingLog(
+                    date: today,
+                    didTrain: true,
+                    menuName: "ペース走",
+                    distanceKm: 10.0,
+                    durationMinutes: 48,
+                    rpe: 6,
+                    hasPain: false,
+                    painArea: "",
+                    trainingMemo: "予定通り完了"
+                )
+            ),
+            DailyRecord(
+                id: UUID(),
+                athleteID: athletes[2].id,
+                date: today,
+                morningCheckIn: MorningCheckIn(
+                    date: today,
+                    sleepHours: 5.4,
+                    sleepQuality: 3,
+                    fatigueLevel: 3,
+                    muscleSoreness: 3,
+                    moodLevel: 3,
+                    physicalConditionMemo: "少し脚が重い",
+                    workHours: 10.0,
+                    hadOvertime: true,
+                    workStressLevel: 3
+                ),
+                trainingLog: nil
+            )
+        ]
+    }()
+
+    static let comments: [CoachComment] = [
+        CoachComment(
+            id: UUID(),
+            athleteID: athletes[0].id,
+            date: Date(),
+            authorName: "田中コーチ",
+            message: "右もものケアを最優先に。明日はジョグのみでOKです。"
+        ),
+        CoachComment(
+            id: UUID(),
+            athleteID: athletes[1].id,
+            date: Date(),
+            authorName: "田中コーチ",
+            message: "良い流れです。明日はペース維持を意識しましょう。"
+        )
+    ]
+}

--- a/TrainingDiaryApp/TrainingDiaryApp.swift
+++ b/TrainingDiaryApp/TrainingDiaryApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct TrainingDiaryApp: App {
+    @StateObject private var store = DiaryStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootTabView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/TrainingDiaryApp/ViewModels/DiaryStore.swift
+++ b/TrainingDiaryApp/ViewModels/DiaryStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@MainActor
+final class DiaryStore: ObservableObject {
+    @Published var athletes: [Athlete] = []
+    @Published var dailyRecords: [DailyRecord] = []
+    @Published var comments: [CoachComment] = []
+
+    private let repository: DiaryRepository
+    private let alertEngine = AlertRuleEngine()
+
+    init(repository: DiaryRepository = InMemoryDiaryRepository()) {
+        self.repository = repository
+        load()
+    }
+
+    func load() {
+        athletes = repository.fetchAthletes()
+        dailyRecords = repository.fetchDailyRecords()
+        comments = repository.fetchComments()
+    }
+
+    func record(for athleteID: UUID, date: Date = Date()) -> DailyRecord? {
+        let day = Calendar.current.startOfDay(for: date)
+        return dailyRecords.first { $0.athleteID == athleteID && Calendar.current.isDate($0.date, inSameDayAs: day) }
+    }
+
+    func statusList(for date: Date = Date()) -> [AthleteDailyStatus] {
+        athletes.map { athlete in
+            let target = record(for: athlete.id, date: date)
+            let (level, reasons) = alertEngine.evaluate(record: target)
+            return AthleteDailyStatus(athlete: athlete, record: target, alertLevel: level, alertReasons: reasons)
+        }
+    }
+
+    func updateMorningCheckIn(for athleteID: UUID, checkIn: MorningCheckIn) {
+        upsertRecord(for: athleteID) { $0.morningCheckIn = checkIn }
+    }
+
+    func updateTrainingLog(for athleteID: UUID, trainingLog: TrainingLog) {
+        upsertRecord(for: athleteID) { $0.trainingLog = trainingLog }
+    }
+
+    func addComment(athleteID: UUID, author: String, message: String) {
+        let newComment = CoachComment(
+            id: UUID(),
+            athleteID: athleteID,
+            date: Date(),
+            authorName: author,
+            message: message
+        )
+        comments.insert(newComment, at: 0)
+    }
+
+    func comments(for athleteID: UUID) -> [CoachComment] {
+        comments
+            .filter { $0.athleteID == athleteID }
+            .sorted { $0.date > $1.date }
+    }
+
+    private func upsertRecord(for athleteID: UUID, update: (inout DailyRecord) -> Void) {
+        let today = Calendar.current.startOfDay(for: Date())
+
+        if let index = dailyRecords.firstIndex(where: { $0.athleteID == athleteID && Calendar.current.isDate($0.date, inSameDayAs: today) }) {
+            update(&dailyRecords[index])
+        } else {
+            var newRecord = DailyRecord(id: UUID(), athleteID: athleteID, date: today, morningCheckIn: nil, trainingLog: nil)
+            update(&newRecord)
+            dailyRecords.append(newRecord)
+        }
+    }
+}

--- a/TrainingDiaryApp/Views/Athlete/AthleteHomeView.swift
+++ b/TrainingDiaryApp/Views/Athlete/AthleteHomeView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct AthleteHomeView: View {
+    @EnvironmentObject private var store: DiaryStore
+    let athlete: Athlete
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("今日の入力") {
+                    NavigationLink("朝チェックインを入力") {
+                        MorningCheckInView(athlete: athlete)
+                    }
+                    NavigationLink("練習後入力を記録") {
+                        TrainingLogView(athlete: athlete)
+                    }
+                }
+
+                Section("指導者コメント") {
+                    NavigationLink("コメントを確認") {
+                        CommentListView(athlete: athlete)
+                    }
+                }
+
+                if let status = store.statusList().first(where: { $0.athlete.id == athlete.id }) {
+                    Section("今日の状態") {
+                        HStack {
+                            Text("判定")
+                            Spacer()
+                            AlertBadgeView(level: status.alertLevel)
+                        }
+                        Text(status.alertReasons.joined(separator: " / "))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("選手ホーム")
+        }
+    }
+}

--- a/TrainingDiaryApp/Views/Athlete/CommentListView.swift
+++ b/TrainingDiaryApp/Views/Athlete/CommentListView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct CommentListView: View {
+    @EnvironmentObject private var store: DiaryStore
+    let athlete: Athlete
+
+    var body: some View {
+        List {
+            ForEach(store.comments(for: athlete.id)) { comment in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(comment.authorName)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Spacer()
+                        Text(comment.date.formatted(date: .abbreviated, time: .shortened))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(comment.message)
+                        .font(.body)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .navigationTitle("コメント確認")
+    }
+}

--- a/TrainingDiaryApp/Views/Athlete/MorningCheckInView.swift
+++ b/TrainingDiaryApp/Views/Athlete/MorningCheckInView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct MorningCheckInView: View {
+    @EnvironmentObject private var store: DiaryStore
+    @Environment(\.dismiss) private var dismiss
+
+    let athlete: Athlete
+
+    @State private var sleepHours: Double = 6
+    @State private var sleepQuality = 3
+    @State private var fatigueLevel = 3
+    @State private var muscleSoreness = 3
+    @State private var moodLevel = 3
+    @State private var physicalConditionMemo = ""
+    @State private var workHours: Double = 8
+    @State private var hadOvertime = false
+    @State private var workStressLevel = 3
+
+    var body: some View {
+        Form {
+            Section("睡眠") {
+                HStack {
+                    Text("睡眠時間")
+                    Spacer()
+                    Text(String(format: "%.1f 時間", sleepHours))
+                }
+                Slider(value: $sleepHours, in: 3...10, step: 0.5)
+                RatingInputRow(title: "睡眠の質", range: 1...5, value: $sleepQuality)
+            }
+
+            Section("コンディション") {
+                RatingInputRow(title: "疲労感", range: 1...5, value: $fatigueLevel)
+                RatingInputRow(title: "筋肉痛", range: 1...5, value: $muscleSoreness)
+                RatingInputRow(title: "気分", range: 1...5, value: $moodLevel)
+                TextField("体調メモ", text: $physicalConditionMemo, axis: .vertical)
+                    .lineLimit(2...4)
+            }
+
+            Section("勤務負荷") {
+                HStack {
+                    Text("勤務時間")
+                    Spacer()
+                    Text(String(format: "%.1f 時間", workHours))
+                }
+                Slider(value: $workHours, in: 4...14, step: 0.5)
+                Toggle("残業あり", isOn: $hadOvertime)
+                RatingInputRow(title: "仕事ストレス", range: 1...5, value: $workStressLevel)
+            }
+
+            Button("保存する") {
+                let checkIn = MorningCheckIn(
+                    date: Date(),
+                    sleepHours: sleepHours,
+                    sleepQuality: sleepQuality,
+                    fatigueLevel: fatigueLevel,
+                    muscleSoreness: muscleSoreness,
+                    moodLevel: moodLevel,
+                    physicalConditionMemo: physicalConditionMemo,
+                    workHours: workHours,
+                    hadOvertime: hadOvertime,
+                    workStressLevel: workStressLevel
+                )
+                store.updateMorningCheckIn(for: athlete.id, checkIn: checkIn)
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .navigationTitle("朝チェックイン")
+    }
+}

--- a/TrainingDiaryApp/Views/Athlete/TrainingLogView.swift
+++ b/TrainingDiaryApp/Views/Athlete/TrainingLogView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct TrainingLogView: View {
+    @EnvironmentObject private var store: DiaryStore
+    @Environment(\.dismiss) private var dismiss
+
+    let athlete: Athlete
+
+    @State private var didTrain = true
+    @State private var menuName = ""
+    @State private var distanceKm: Double = 5
+    @State private var durationMinutes = 45
+    @State private var rpe = 5
+    @State private var hasPain = false
+    @State private var painArea = ""
+    @State private var trainingMemo = ""
+
+    var body: some View {
+        Form {
+            Section("練習実施") {
+                Toggle("練習を実施した", isOn: $didTrain)
+                TextField("メニュー名", text: $menuName)
+                if didTrain {
+                    HStack {
+                        Text("距離")
+                        Spacer()
+                        Text(String(format: "%.1f km", distanceKm))
+                    }
+                    Slider(value: $distanceKm, in: 0...30, step: 0.5)
+
+                    Stepper("時間: \(durationMinutes) 分", value: $durationMinutes, in: 0...240, step: 5)
+                    RatingInputRow(title: "RPE", range: 1...10, value: $rpe)
+                }
+            }
+
+            Section("痛み") {
+                Toggle("痛みあり", isOn: $hasPain)
+                if hasPain {
+                    TextField("痛み部位", text: $painArea)
+                }
+            }
+
+            Section("メモ") {
+                TextField("練習メモ", text: $trainingMemo, axis: .vertical)
+                    .lineLimit(2...4)
+            }
+
+            Button("保存する") {
+                let log = TrainingLog(
+                    date: Date(),
+                    didTrain: didTrain,
+                    menuName: menuName,
+                    distanceKm: didTrain ? distanceKm : nil,
+                    durationMinutes: didTrain ? durationMinutes : nil,
+                    rpe: didTrain ? rpe : 1,
+                    hasPain: hasPain,
+                    painArea: hasPain ? painArea : "",
+                    trainingMemo: trainingMemo
+                )
+                store.updateTrainingLog(for: athlete.id, trainingLog: log)
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .navigationTitle("練習後入力")
+    }
+}

--- a/TrainingDiaryApp/Views/Coach/AthleteDetailView.swift
+++ b/TrainingDiaryApp/Views/Coach/AthleteDetailView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct AthleteDetailView: View {
+    @EnvironmentObject private var store: DiaryStore
+
+    let status: AthleteDailyStatus
+
+    @State private var coachName = "田中コーチ"
+    @State private var commentText = ""
+
+    var body: some View {
+        List {
+            Section("選手情報") {
+                LabeledContent("氏名", value: status.athlete.name)
+                LabeledContent("所属", value: status.athlete.company)
+                LabeledContent("種目", value: status.athlete.event)
+                HStack {
+                    Text("注意判定")
+                    Spacer()
+                    AlertBadgeView(level: status.alertLevel)
+                }
+                Text(status.alertReasons.joined(separator: " / "))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("朝チェックイン") {
+                if let morning = status.record?.morningCheckIn {
+                    LabeledContent("睡眠", value: String(format: "%.1f 時間", morning.sleepHours))
+                    LabeledContent("睡眠の質", value: "\(morning.sleepQuality)/5")
+                    LabeledContent("疲労感", value: "\(morning.fatigueLevel)/5")
+                    LabeledContent("勤務", value: String(format: "%.1f 時間", morning.workHours))
+                    LabeledContent("残業", value: morning.hadOvertime ? "あり" : "なし")
+                    Text(morning.physicalConditionMemo)
+                } else {
+                    Text("未入力")
+                }
+            }
+
+            Section("練習後入力") {
+                if let training = status.record?.trainingLog {
+                    LabeledContent("実施", value: training.didTrain ? "あり" : "なし")
+                    LabeledContent("メニュー", value: training.menuName)
+                    LabeledContent("RPE", value: "\(training.rpe)/10")
+                    LabeledContent("痛み", value: training.hasPain ? "あり" : "なし")
+                    if training.hasPain {
+                        LabeledContent("部位", value: training.painArea)
+                    }
+                    Text(training.trainingMemo)
+                } else {
+                    Text("未入力")
+                }
+            }
+
+            Section("コメント送信") {
+                TextField("指導者名", text: $coachName)
+                TextField("コメント", text: $commentText, axis: .vertical)
+                    .lineLimit(2...4)
+
+                Button("コメントを保存") {
+                    guard !commentText.isEmpty else { return }
+                    store.addComment(athleteID: status.athlete.id, author: coachName, message: commentText)
+                    commentText = ""
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .navigationTitle("選手詳細")
+    }
+}

--- a/TrainingDiaryApp/Views/Coach/CoachDashboardView.swift
+++ b/TrainingDiaryApp/Views/Coach/CoachDashboardView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct CoachDashboardView: View {
+    @EnvironmentObject private var store: DiaryStore
+
+    var body: some View {
+        NavigationStack {
+            List(store.statusList()) { status in
+                NavigationLink {
+                    AthleteDetailView(status: status)
+                } label: {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(status.athlete.name)
+                                    .font(.headline)
+                                Text("\(status.athlete.company) / \(status.athlete.event)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            AlertBadgeView(level: status.alertLevel)
+                        }
+
+                        statusSummary(status)
+                            .font(.subheadline)
+                        Text(status.alertReasons.joined(separator: " / "))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("指導者ダッシュボード")
+        }
+    }
+
+    @ViewBuilder
+    private func statusSummary(_ status: AthleteDailyStatus) -> some View {
+        let morning = status.record?.morningCheckIn
+        let training = status.record?.trainingLog
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text("入力状況: 朝\(morning == nil ? "✕" : "○") / 練習\(training == nil ? "✕" : "○")")
+            Text("疲労: \(morning?.fatigueLevel ?? 0)  睡眠: \(String(format: "%.1f", morning?.sleepHours ?? 0))h")
+            Text("勤務: \(String(format: "%.1f", morning?.workHours ?? 0))h  残業: \((morning?.hadOvertime ?? false) ? "あり" : "なし")")
+            Text("練習: \((training?.didTrain ?? false) ? "実施" : "未実施")  痛み: \((training?.hasPain ?? false) ? "あり" : "なし")")
+        }
+    }
+}

--- a/TrainingDiaryApp/Views/Common/AlertBadgeView.swift
+++ b/TrainingDiaryApp/Views/Common/AlertBadgeView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct AlertBadgeView: View {
+    let level: AlertLevel
+
+    var body: some View {
+        Text(label)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+
+    private var label: String {
+        switch level {
+        case .normal: return "通常"
+        case .caution: return "注意"
+        case .warning: return "警告"
+        }
+    }
+
+    private var color: Color {
+        switch level {
+        case .normal: return .green
+        case .caution: return .orange
+        case .warning: return .red
+        }
+    }
+}

--- a/TrainingDiaryApp/Views/Common/RatingInputRow.swift
+++ b/TrainingDiaryApp/Views/Common/RatingInputRow.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct RatingInputRow: View {
+    let title: String
+    let range: ClosedRange<Int>
+    @Binding var value: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text("\(value)")
+                    .fontWeight(.semibold)
+            }
+
+            Stepper("", value: $value, in: range)
+                .labelsHidden()
+        }
+    }
+}

--- a/TrainingDiaryApp/Views/RootTabView.swift
+++ b/TrainingDiaryApp/Views/RootTabView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct RootTabView: View {
+    @EnvironmentObject private var store: DiaryStore
+
+    var body: some View {
+        TabView {
+            AthleteHomeView(athlete: store.athletes.first ?? Athlete(id: UUID(), name: "", company: "", event: ""))
+                .tabItem {
+                    Label("選手", systemImage: "figure.run")
+                }
+
+            CoachDashboardView()
+                .tabItem {
+                    Label("指導者", systemImage: "person.3")
+                }
+        }
+    }
+}
+
+#Preview {
+    RootTabView()
+        .environmentObject(DiaryStore())
+}


### PR DESCRIPTION
### Motivation
- Provide an MVP SwiftUI app so corporate athletes can record quick daily morning check-ins and post-training logs while coaches can monitor team status and leave short comments. 
- Keep the UI simple and Japanese-friendly and make the data layer easy to replace with cloud services (e.g., Firebase) later by abstracting the repository. 

### Description
- Add data models and rule engine: created `TrainingDiaryModels.swift` (models such as `Athlete`, `MorningCheckIn`, `TrainingLog`, `DailyRecord`, `CoachComment`, `AlertLevel`, `AthleteDailyStatus`) and `AlertRuleEngine.swift` implementing simple rule-based alerting (sleep <5h, fatigue high, pain, overtime, RPE high). 
- Add repository and sample data: added `DiaryRepository.swift` with `InMemoryDiaryRepository` and `SampleData.swift` containing Japanese dummy athletes/records/comments. 
- Add view model: implemented `DiaryStore` as an `ObservableObject` to load/update records, compute per-athlete status via the alert engine, and manage comments. 
- Add UI and app entry: implemented SwiftUI views and helpers including `RootTabView`, `TrainingDiaryApp` (app entry), athlete views (`AthleteHomeView`, `MorningCheckInView`, `TrainingLogView`, `CommentListView`), coach views (`CoachDashboardView`, `AthleteDetailView`), and common components (`AlertBadgeView`, `RatingInputRow`), plus `README_MVP.md` describing architecture and next steps. 

### Testing
- Committed and verified files were created successfully via `git` (commit message: "Implement SwiftUI MVP for athlete training diary app", created 16 files). 
- Verified local tool availability with `swift --version` which succeeded in this environment. 
- Attempted `xcodebuild -version` but it failed because this CI/runtime is Linux and Xcode/iOS build tools are not available, so no Xcode/iOS build or simulator tests were run. 
- No automated unit tests or iOS UI builds were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85499e0f0832ea02b2fd316dcaa8a)